### PR TITLE
Updates iron to 0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: rust
 rust:
-  - 1.9.0
+  - 1.11.0
   - stable
   - beta
   - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iron-cors"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Danilo Bargen <mail@dbrgn.ch>"]
 repository = "https://github.com/dbrgn/iron-cors-rs/"
 homepage = "https://github.com/dbrgn/iron-cors-rs/"
@@ -11,7 +11,7 @@ description = "A CORS middleware implementation for Iron."
 
 [dependencies]
 log = "0.3"
-iron = "0.4"
+iron = "0.5"
 
 [dev-dependencies]
-iron-test = "0.4.0"
+iron-test = "0.5.0"


### PR DESCRIPTION
Simply updates the version numbers to allow it to work with iron version 0.5.X. Without it tries to pull in iron 0.4 along side 0.5 (since the project I am working on depends on 0.5) then fails to compile with

```
error[E0277]: the trait bound `iron_cors::CorsMiddleware: std::ops::FnOnce<(std::boxed::Box<iron::Handler + 'stat
ic>,)>` is not satisfied
```

Alternatively you can also change the required iron version to be `>= 0.4 < 0.6`, I am not sure if you want to match irons versioning or not.