### PR TITLE
Handle handler errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,7 +186,7 @@ impl Handler for CorsHandlerAllowAny {
         let mut res = try!(self.handler.handle(req));
 
         // Add Access-Control-Allow-Origin header to response
-        res.headers.set(headers::AccessControlAllowOrigin::Value("*".into()));
+        res.headers.set(headers::AccessControlAllowOrigin::Any);
 
         Ok(res)
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3,17 +3,34 @@ extern crate iron_cors;
 extern crate iron_test;
 
 use std::collections::HashSet;
+use std::io::{Error, ErrorKind};
 
-use iron::{Handler, Request, Response, IronResult, Chain, status};
-use iron::headers::{Headers, Origin};
+use iron::{Handler, Request, Response, IronResult, IronError, Chain, status};
+use iron::headers::{Headers, Origin, AccessControlAllowOrigin};
 use self::iron_test::{request, response};
 use iron_cors::CorsMiddleware;
 
 struct HelloWorldHandler;
-
 impl Handler for HelloWorldHandler {
     fn handle(&self, _: &mut Request) -> IronResult<Response> {
         Ok(Response::with((status::Ok, "Hello, world!")))
+    }
+}
+
+struct ForbiddenHandler;
+impl Handler for ForbiddenHandler {
+    fn handle(&self, _: &mut Request) -> IronResult<Response> {
+        Ok(Response::with((status::Forbidden, "You shall not pass!")))
+    }
+}
+
+struct ErrorResultHandler;
+impl Handler for ErrorResultHandler {
+    fn handle(&self, _: &mut Request) -> IronResult<Response> {
+        Err(IronError::new(
+            Error::new(ErrorKind::Other, "terrible things"),
+            (status::InternalServerError, "Oh noes")
+        ))
     }
 }
 
@@ -105,4 +122,46 @@ fn test_allow_any_missing_header_denied() {
     assert_eq!(response.status, Some(status::BadRequest));
     let result_body = response::extract_body_to_string(response);
     assert_eq!(&result_body, "Invalid CORS request: Origin header missing");
+}
+
+#[test]
+fn test_intended_error_status() {
+    //! A regular non-200 response should contain CORS headers.
+    let mut handler = Chain::new(ForbiddenHandler {});
+    handler.link_around(CorsMiddleware::with_allow_any(true));
+    let headers = setup_origin_header!("example.org");
+    let response = request::get("http://example.org:3000/forbidden", headers, &handler).unwrap();
+    assert_eq!(response.status, Some(status::Forbidden));
+    assert!(response.headers.has::<AccessControlAllowOrigin>());
+    let result_body = response::extract_body_to_string(response);
+    assert_eq!(&result_body, "You shall not pass!");
+}
+
+#[test]
+fn test_unexpected_error_status_allow_any() {
+    //! A response from an error inside a handler should contain CORS headers.
+    let mut handler = Chain::new(ErrorResultHandler {});
+    handler.link_around(CorsMiddleware::with_allow_any(true));
+    let headers = setup_origin_header!("example.org");
+    let error = request::get("http://example.org:3000/err", headers, &handler).unwrap_err();
+    let response = error.response;
+    assert_eq!(response.status, Some(status::InternalServerError));
+    assert!(response.headers.has::<AccessControlAllowOrigin>());
+    let result_body = response::extract_body_to_string(response);
+    assert_eq!(&result_body, "Oh noes");
+}
+
+#[test]
+fn test_unexpected_error_status_whitelist() {
+    //! A response from an error inside a handler should contain CORS headers.
+    let mut handler = Chain::new(ErrorResultHandler {});
+    let whitelist = ["example.org"].iter().map(ToString::to_string).collect::<HashSet<_>>();
+    handler.link_around(CorsMiddleware::with_whitelist(whitelist));
+    let headers = setup_origin_header!("example.org");
+    let error = request::get("http://example.org:3000/err", headers, &handler).unwrap_err();
+    let response = error.response;
+    assert_eq!(response.status, Some(status::InternalServerError));
+    assert!(response.headers.has::<AccessControlAllowOrigin>());
+    let result_body = response::extract_body_to_string(response);
+    assert_eq!(&result_body, "Oh noes");
 }


### PR DESCRIPTION
Responses caused by an error result in a handler should also contain CORS headers.

Fixes #4.