### PR TITLE
Always process non-CORS requests as usual

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,6 @@ A CORS Middleware for [Iron](http://ironframework.io/).
 See https://www.html5rocks.com/static/images/cors_server_flowchart.png for
 reference.
 
-The middleware will return `HTTP 400 Bad Request` if the origin host is missing
-(configurable) or not allowed.
-
 Preflight requests are not yet supported. Pull requests adding it are welcome.
 
 Docs: https://docs.rs/iron-cors/

--- a/examples/allow_any.rs
+++ b/examples/allow_any.rs
@@ -17,7 +17,7 @@ fn main() {
     let handler = HelloWorldHandler {};
 
     // Initialize middleware
-    let cors_middleware = CorsMiddleware::with_allow_any(true);
+    let cors_middleware = CorsMiddleware::with_allow_any();
     println!("Allowed origin hosts: *");
 
     // Setup chain with middleware


### PR DESCRIPTION
There is no reason we should return a HTTP 400 response to non-CORS requests.

Fixes #7 

@DavidBM does this look reasonable to you?