### PR TITLE
add preflight call & fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: rust
 rust:
-  - 1.11.0
+  - 1.17.0
   - stable
   - beta
   - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ iron = "0.5"
 
 [dev-dependencies]
 iron-test = "0.5.0"
+unicase = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iron-cors"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Danilo Bargen <mail@dbrgn.ch>"]
 repository = "https://github.com/dbrgn/iron-cors-rs/"
 homepage = "https://github.com/dbrgn/iron-cors-rs/"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A CORS Middleware for [Iron](http://ironframework.io/).
 See https://www.html5rocks.com/static/images/cors_server_flowchart.png for
 reference.
 
-Preflight requests are not yet supported. Pull requests adding it are welcome.
+Preflight requests **are supported**! :D
 
 Docs: https://docs.rs/iron-cors/
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,8 +154,8 @@ impl CorsHandlerWhitelist {
             }
         }  
 
-        // If we don't have an Access-Control-Request-Method header, is not a preflight
-        self.handler.handle(req)
+        // If we don't have an Access-Control-Request-Method header, treat as a possible OPTION CORS call
+        return self.process_possible_cors_request(req, origin)
     }
 
     fn process_possible_cors_request(&self, req: &mut Request, origin: headers::Origin) -> IronResult<Response> {
@@ -238,8 +238,8 @@ impl CorsHandlerAllowAny {
             }
         }  
 
-        // If we don't have an Access-Control-Request-Method header, is not a preflight
-        self.handler.handle(req)
+        // If we don't have an Access-Control-Request-Method header, treat as a possible OPTION CORS call
+        return self.process_possible_cors_request(req)
     }
 
     fn process_possible_cors_request(&self, req: &mut Request) -> IronResult<Response> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,6 +117,7 @@ impl CorsHandlerWhitelist {
                                   origin: &headers::Origin, 
                                   acrm: &headers::AccessControlRequestMethod, 
                                   acrh: Option<&headers::AccessControlRequestHeaders>) {
+
         self.add_cors_header(headers, origin);
 
         //Copy the method requested by the browser in the allowed methods header
@@ -204,7 +205,11 @@ impl CorsHandlerAllowAny {
         headers.set(headers::AccessControlAllowOrigin::Any);
     }
 
-    fn add_cors_preflight_headers(&self, headers: &mut headers::Headers, acrm: &headers::AccessControlRequestMethod, acrh: Option<&headers::AccessControlRequestHeaders>) {
+    fn add_cors_preflight_headers(&self, 
+                                  headers: &mut headers::Headers, 
+                                  acrm: &headers::AccessControlRequestMethod, 
+                                  acrh: Option<&headers::AccessControlRequestHeaders>) {
+
         self.add_cors_header(headers);
 
         //Copy the method requested by the browser in the allowed methods header

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,11 @@ impl CorsHandlerWhitelist {
         headers.set(headers::AccessControlAllowOrigin::Value(header));
     }
 
-    fn add_cors_preflight_headers(&self, headers: &mut headers::Headers, origin: &headers::Origin, acrm: &headers::AccessControlRequestMethod, acrh: Option<&headers::AccessControlRequestHeaders>) {
+    fn add_cors_preflight_headers(&self, 
+                                  headers: &mut headers::Headers, 
+                                  origin: &headers::Origin, 
+                                  acrm: &headers::AccessControlRequestMethod, 
+                                  acrh: Option<&headers::AccessControlRequestHeaders>) {
         self.add_cors_header(headers, origin);
 
         //Copy the method requested by the browser in the allowed methods header

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,8 @@ extern crate iron;
 use std::collections::HashSet;
 
 use iron::{Request, Response, IronResult, AroundMiddleware, Handler};
+use iron::method::Method;
+use iron::status;
 use iron::headers;
 
 /// The struct that holds the CORS configuration.
@@ -106,11 +108,65 @@ struct CorsHandlerAllowAny {
 
 impl CorsHandlerWhitelist {
     fn add_cors_header(&self, headers: &mut headers::Headers, origin: &headers::Origin) {
-        let header = match origin.host.port {
-            Some(port) => format!("{}://{}:{}", &origin.scheme, &origin.host.hostname, &port),
-            None => format!("{}://{}", &origin.scheme, &origin.host.hostname),
-        };
+        let header = format_cors_origin(origin);
         headers.set(headers::AccessControlAllowOrigin::Value(header));
+    }
+
+    fn add_cors_preflight_headers(&self, headers: &mut headers::Headers, origin: &headers::Origin, acrm: &headers::AccessControlRequestMethod, acrh: Option<&headers::AccessControlRequestHeaders>) {
+        self.add_cors_header(headers, origin);
+
+        //Copy the method requested by the browser in the allowed methods header
+        headers.set(headers::AccessControlAllowMethods(vec!(acrm.0.clone())));
+        
+        //If we have special allowed headers, copy them in the allowed headers in the response
+        if let Some(acrh) = acrh {
+            headers.set(headers::AccessControlAllowHeaders(acrh.0.clone()));
+        }
+    }
+
+    fn process_possible_preflight(&self, req: &mut Request, origin: headers::Origin) -> IronResult<Response> {
+        // Verify origin header
+        let may_process = self.allowed_hosts.contains(&format_cors_origin(&origin));
+
+        if !may_process {
+            warn!("Got disallowed preflight CORS request from {}", &origin.host.hostname);
+            return Ok(Response::with((status::BadRequest, "Invalid CORS request: Origin not allowed")));
+        }
+
+        {
+            let acrm = req.headers.get::<headers::AccessControlRequestMethod>();
+
+            //Check the Access-Control-Request-Method header
+            if let Some(acrm) = acrm {
+                //Asuming that Access-Control-Request-Method header is valid (headers names can be anything)
+                let acrh = req.headers.get::<headers::AccessControlRequestHeaders>();
+
+                let mut response = Response::with((status::Ok, ""));
+                self.add_cors_preflight_headers(&mut response.headers, &origin, acrm, acrh);
+
+                //In case of preflight, return 200 with empty body after adding the preflight headers
+                return Ok(response);
+            }
+        }  
+
+        // If we don't have an Access-Control-Request-Method header, is not a preflight
+        self.handler.handle(req)
+    }
+
+    fn process_possible_cors_request(&self, req: &mut Request, origin: headers::Origin) -> IronResult<Response> {
+        // Verify origin header
+        let may_process = self.allowed_hosts.contains(&format_cors_origin(&origin));
+        // Process request
+        if may_process {
+            // Everything OK, process request and add CORS header to response
+            self.handler.handle(req)
+                .map(|mut res| { self.add_cors_header(&mut res.headers, &origin); res })
+                .map_err(|mut err| { self.add_cors_header(&mut err.response.headers, &origin); err })
+        } else {
+            // Not adding headers
+            warn!("Got disallowed CORS request from {}", &origin.host.hostname);
+            Ok(Response::with((status::BadRequest, "Invalid CORS request: Origin not allowed")))
+        }
     }
 }
 
@@ -130,19 +186,11 @@ impl Handler for CorsHandlerWhitelist {
             }
         };
 
-        // Verify origin header
-        let may_process = self.allowed_hosts.contains(&origin.host.hostname);
-
-        // Process request
-        if may_process {
-            // Everything OK, process request and add CORS header to response
-            self.handler.handle(req)
-                .map(|mut res| { self.add_cors_header(&mut res.headers, &origin); res })
-                .map_err(|mut err| { self.add_cors_header(&mut err.response.headers, &origin); err })
-        } else {
-            // Not adding headers
-            warn!("Got disallowed CORS request from {}", &origin.host.hostname);
-            self.handler.handle(req)
+        match req.method {
+            //If is an OPTION request, check for preflight 
+            Method::Options => self.process_possible_preflight(req, origin),
+            // If is not an OPTION request, we asume a normal CORS (no preflight)
+            _ => self.process_possible_cors_request(req, origin),
         }
     }
 }
@@ -150,6 +198,45 @@ impl Handler for CorsHandlerWhitelist {
 impl CorsHandlerAllowAny {
     fn add_cors_header(&self, headers: &mut headers::Headers) {
         headers.set(headers::AccessControlAllowOrigin::Any);
+    }
+
+    fn add_cors_preflight_headers(&self, headers: &mut headers::Headers, acrm: &headers::AccessControlRequestMethod, acrh: Option<&headers::AccessControlRequestHeaders>) {
+        self.add_cors_header(headers);
+
+        //Copy the method requested by the browser in the allowed methods header
+        headers.set(headers::AccessControlAllowMethods(vec!(acrm.0.clone())));
+        
+        //If we have special allowed headers, copy them in the allowed headers in the response
+        if let Some(acrh) = acrh {
+            headers.set(headers::AccessControlAllowHeaders(acrh.0.clone()));
+        }
+    }
+
+    fn process_possible_preflight(&self, req: &mut Request) -> IronResult<Response> {
+        {
+            let acrm = req.headers.get::<headers::AccessControlRequestMethod>();
+
+            //Check the Access-Control-Request-Method header
+            if let Some(acrm) = acrm {
+                //Asuming that Access-Control-Request-Method header is valid (headers names can be anything)
+                let acrh = req.headers.get::<headers::AccessControlRequestHeaders>();
+
+                let mut response = Response::with((status::Ok, ""));
+                self.add_cors_preflight_headers(&mut response.headers, acrm, acrh);
+
+                //In case of preflight, return 200 with empty body after adding the preflight headers
+                return Ok(response);
+            }
+        }  
+
+        // If we don't have an Access-Control-Request-Method header, is not a preflight
+        self.handler.handle(req)
+    }
+
+    fn process_possible_cors_request(&self, req: &mut Request) -> IronResult<Response> {
+        self.handler.handle(req)
+            .map(|mut res| { self.add_cors_header(&mut res.headers); res })
+            .map_err(|mut err| { self.add_cors_header(&mut err.response.headers); err })
     }
 }
 
@@ -165,11 +252,20 @@ impl Handler for CorsHandlerAllowAny {
                 self.handler.handle(req)
             },
             Some(_) => {
-                self.handler.handle(req)
-                    .map(|mut res| { self.add_cors_header(&mut res.headers); res })
-                    .map_err(|mut err| { self.add_cors_header(&mut err.response.headers); err })
+                match req.method {
+                    //If is an OPTION request, check for preflight 
+                    Method::Options => self.process_possible_preflight(req),
+                    // If is not an OPTION request, we asume a normal CORS (no preflight)
+                    _ => self.process_possible_cors_request(req),
+                }
             },
         }
+    }
+}
 
+fn format_cors_origin(origin: &headers::Origin) -> String {
+    match origin.host.port {
+        Some(port) => format!("{}://{}:{}", &origin.scheme, &origin.host.hostname, &port),
+        None => format!("{}://{}", &origin.scheme, &origin.host.hostname),
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -285,7 +285,7 @@ fn test_any_preflight_with_cors_headers() {
         let mut headers = Headers::new();
         headers.set(Origin::new("http", "example.org", Some(3000)));
         headers.set(AccessControlRequestMethod(iron::method::Get));
-        headers.set(AccessControlRequestHeaders(vec!(UniCase("header1".to_string()),UniCase("header2".to_string()))));
+        headers.set(AccessControlRequestHeaders(vec![UniCase("header1".to_string()),UniCase("header2".to_string())]));
         headers
     };
 
@@ -301,13 +301,13 @@ fn test_any_preflight_with_cors_headers() {
     {
     let header = response.headers.get::<AccessControlAllowHeaders>();
     assert!(header.is_some());
-    assert_eq!(*header.unwrap(), AccessControlAllowHeaders(vec!(UniCase("header1".to_string()),UniCase("header2".to_string()))));
+    assert_eq!(*header.unwrap(), AccessControlAllowHeaders(vec![UniCase("header1".to_string()),UniCase("header2".to_string())]));
     }
 
     {
     let header = response.headers.get::<AccessControlAllowMethods>();
     assert!(header.is_some());
-    assert_eq!(*header.unwrap(), AccessControlAllowMethods(vec!(iron::method::Get)));
+    assert_eq!(*header.unwrap(), AccessControlAllowMethods(vec![iron::method::Get]));
     }
 
     let result_body = response::extract_body_to_string(response);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -258,25 +258,6 @@ fn test_whitelist_preflight_with_cors_headers() {
 }
 
 #[test]
-fn test_whitelist_preflight_without_cors_headers() {
-    //! OPTION requests with whitelisted host without CORS headers should answer call the normal handler without modify anything
-    let handler = setup_handler!("whitelist": ["http://example.org:3000"]);
-    
-    let headers = setup_origin_header!("example.org", 3000);
-
-    let response = request::options("http://example.org:3000/hello", headers, &handler).unwrap();
-    assert_eq!(response.status, Some(status::Ok));
-
-    {
-    let header = response.headers.get::<AccessControlAllowOrigin>();
-    assert!(!header.is_some());
-    }
-
-    let result_body = response::extract_body_to_string(response);
-    assert_eq!(&result_body, "Hello, world!");
-}
-
-#[test]
 fn test_any_preflight_with_cors_headers() {
     //! OPTION requests with allow all hosts and correct CORS headers should answer 200 with empty body and the CORS headers 
     let handler = setup_handler!("any");
@@ -312,23 +293,4 @@ fn test_any_preflight_with_cors_headers() {
 
     let result_body = response::extract_body_to_string(response);
     assert_eq!(&result_body, "");
-}
-
-#[test]
-fn test_any_preflight_without_cors_headers() {
-    //! OPTION requests with allow all hosts without CORS headers should answer call the normal handler without modify anything
-    let handler = setup_handler!("any");
-    
-    let headers = setup_origin_header!("example.org", 3000);
-
-    let response = request::options("http://example.org:3000/hello", headers, &handler).unwrap();
-    assert_eq!(response.status, Some(status::Ok));
-
-    {
-    let header = response.headers.get::<AccessControlAllowOrigin>();
-    assert!(!header.is_some());
-    }
-
-    let result_body = response::extract_body_to_string(response);
-    assert_eq!(&result_body, "Hello, world!");
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -228,7 +228,7 @@ fn test_whitelist_preflight_with_cors_headers() {
         let mut headers = Headers::new();
         headers.set(Origin::new("http", "example.org", Some(3000)));
         headers.set(AccessControlRequestMethod(iron::method::Get));
-        headers.set(AccessControlRequestHeaders(vec!(UniCase("header1".to_string()),UniCase("header2".to_string()))));
+        headers.set(AccessControlRequestHeaders(vec![UniCase("header1".to_string()),UniCase("header2".to_string())]));
         headers
     };
 
@@ -244,13 +244,13 @@ fn test_whitelist_preflight_with_cors_headers() {
     {
     let header = response.headers.get::<AccessControlAllowHeaders>();
     assert!(header.is_some());
-    assert_eq!(*header.unwrap(), AccessControlAllowHeaders(vec!(UniCase("header1".to_string()),UniCase("header2".to_string()))));
+    assert_eq!(*header.unwrap(), AccessControlAllowHeaders(vec![UniCase("header1".to_string()),UniCase("header2".to_string())]));
     }
 
     {
     let header = response.headers.get::<AccessControlAllowMethods>();
     assert!(header.is_some());
-    assert_eq!(*header.unwrap(), AccessControlAllowMethods(vec!(iron::method::Get)));
+    assert_eq!(*header.unwrap(), AccessControlAllowMethods(vec![iron::method::Get]));
     }
 
     let result_body = response::extract_body_to_string(response);


### PR DESCRIPTION
I added preflight capability.

Here some details: 
- Added tests for preflight
- Added unicase dev dependency for tests
- Corrected some tests
  - Cors uses always the protocol (`http`), the host (`domain.com`) and the port (`3000`). The tests where ignoring the port.
- The code don't have any special case for a bad formed "AccessControlRequestHeaders" as the CORS protocol says. I'm just copying it if is present and is correct parsed by iron. Basically because is correct doing a CORS without special headers.
- If no AccessControlRequestMethod, the code assumes that is not a preflight, as the CORS protocol says.
- In the case of whitelist, when Origin is present and is not in the list, a BadRequest is returned. This is for avoiding the case that I mention on https://github.com/dbrgn/iron-cors-rs/issues/7#issuecomment-293645251


Maybe the code breaks the usage, but not the API. Now the user must provide a string like `http://domain.com:3000` instead of `domain.com`. CORS establish the need for protocol and port in the comparation. That means that for CORS is not the same `http://domain.com:3001` than `http://domain.com:3000` or `https://domain.com:3000` than `http://domain.com:3000`. You can see the update in the way of comparing in the line 150. 

This happened for using strings instead of the type `iron::headers::Origin`. In my opinion the user should provide an array of `iron::headers::Origin` instead of hashes (`iron::headers::Origin` implement the trait `FromStr::from_str`) . But this is for other pull request, I don't want to break the API :stuck_out_tongue: 

Let me know if you want any change.