### PR TITLE
examples: fix `with_allow_any`

### DIFF
--- a/examples/allow_any.rs
+++ b/examples/allow_any.rs
@@ -17,7 +17,7 @@ fn main() {
     let handler = HelloWorldHandler {};
 
     // Initialize middleware
-    let cors_middleware = CorsMiddleware::with_allow_any();
+    let cors_middleware = CorsMiddleware::with_allow_any(true);
     println!("Allowed origin hosts: *");
 
     // Setup chain with middleware


### PR DESCRIPTION
As I read in the docs, the function `with_allow_any` expects a boolean argument, but in `examples/allow_any.rs` none is provided, causing an compile time error. This PR wants to fix it.