### PR TITLE
Update iron version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ readme = "README.md"
 description = "A CORS middleware implementation for Iron."
 
 [dependencies]
-log = "0.3"
-iron = "0.5"
+log = "0.4"
+iron = "0.6"
 
 [dev-dependencies]
-iron-test = "0.5.0"
+iron-test = "0.6.0"
 unicase = "1.4.0"


### PR DESCRIPTION
Hi!

This just bumps Iron dependency, to make this crate usable with 0.6.

This also bumps log to 0.4: https://users.rust-lang.org/t/log-0-4-0-released/14608